### PR TITLE
Added confluent control center instead of Kowl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cluster-data/
+enterprise-cluster-data/
 **/*.env

--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ Set it changing `YOUR_IP` inside `.env`, `producer/.env` and `consumer/.env`
 
 ## 2. Starting Kafka
 
-Start the cluster :
+You have two choices : starting the open-source Kafka version or the Enterprise one. The latter will allow you to benefit from all the features in the Confluent Control Center, especially the metrics.
+
+To start the open-source cluster :
 
 ```bash
 docker-compose up -d
+```
+
+To start the enterprise cluster :
+
+```bash
+docker-compose -f docker-compose.enterprise.yml up -d
 ```
 
 ## 3. Adding and feeding a topic (producer)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project includes :
 
 - 1 Kafka cluster of 3 brokers
 - 1 ZooKeeper cluster of 3 workers
-- 1 Kowl UI (Kafka activity monitoring)
+- 1 Confluent Control Center (Kafka UI)
 - 1 Python example of producer
 - 1 Python example of consumer
 
@@ -58,7 +58,7 @@ docker-compose -f ./consumer/docker-compose.yml up
 
 ## 5. (optional) Watch the UI
 
-Connect to [`localhost:8080`](http://localhost:8080) to visualize your cluster activity
+Connect to [`localhost:9021`](http://localhost:9021) to visualize your cluster activity
 
 ![Kowl UI example](./images/UI.png)
 

--- a/config-kowl.yaml
+++ b/config-kowl.yaml
@@ -1,9 +1,0 @@
-# See: https://github.com/cloudhut/kowl/tree/master/docs/config for reference config files.
-kafka:
-    brokers:
-        - kafka1:19092
-        - kafka2:19093
-        - kafka3:19094
-
-# server:
-    # listenPort: 8080

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -37,8 +37,8 @@ services:
             ZOO_PORT: 2181
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
         volumes:
-            - ./cluster-data/zoo1/data:/data
-            - ./cluster-data/zoo1/datalog:/datalog
+            - ./enterprise-cluster-data/zoo1/data:/data
+            - ./enterprise-cluster-data/zoo1/datalog:/datalog
 
     zoo2:
         image: zookeeper:3.4.9
@@ -51,8 +51,8 @@ services:
             ZOO_PORT: 2182
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
         volumes:
-            - ./cluster-data/zoo2/data:/data
-            - ./cluster-data/zoo2/datalog:/datalog
+            - ./enterprise-cluster-data/zoo2/data:/data
+            - ./enterprise-cluster-data/zoo2/datalog:/datalog
 
     zoo3:
         image: zookeeper:3.4.9
@@ -65,12 +65,12 @@ services:
             ZOO_PORT: 2183
             ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
         volumes:
-            - ./cluster-data/zoo3/data:/data
-            - ./cluster-data/zoo3/datalog:/datalog
+            - ./enterprise-cluster-data/zoo3/data:/data
+            - ./enterprise-cluster-data/zoo3/datalog:/datalog
 
 
     kafka1:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka1
         ports:
@@ -83,15 +83,20 @@ services:
             KAFKA_BROKER_ID: 1
             KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka1:19092"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
-            - ./cluster-data/kafka1/data:/var/lib/kafka/data
+            - ./enterprise-cluster-data/kafka1/data:/var/lib/kafka/data
         depends_on:
             - zoo1
             - zoo2
             - zoo3
 
     kafka2:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka2
         ports:
@@ -104,15 +109,20 @@ services:
             KAFKA_BROKER_ID: 2
             KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka2:19093"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
-            - ./cluster-data/kafka2/data:/var/lib/kafka/data
+            - ./enterprise-cluster-data/kafka2/data:/var/lib/kafka/data
         depends_on:
             - zoo1
             - zoo2
             - zoo3
 
     kafka3:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka3
         ports:
@@ -125,8 +135,13 @@ services:
             KAFKA_BROKER_ID: 3
             KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka3:19094"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
-            - ./cluster-data/kafka3/data:/var/lib/kafka/data
+            - ./enterprise-cluster-data/kafka3/data:/var/lib/kafka/data
         depends_on:
             - zoo1
             - zoo2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,30 @@
 version: '3.7'
 
 services:
-
-    kowl:
-        image: quay.io/cloudhut/kowl:v1.1.0
-        restart: on-failure
-        hostname: kowl
-        volumes:
-            - type: bind
-              source: ./config-kowl.yaml
-              target: /etc/kowl/config.yaml
-              read_only: true
-        ports:
-        - "8080:8080"
-        entrypoint: ./kowl --config.filepath=/etc/kowl/config.yaml
+    
+    control-center:
+        # https://github.com/confluentinc/cp-demo/blob/5.5.1-post/docker-compose.yml
+        image: confluentinc/cp-enterprise-control-center:5.5.1
         depends_on:
+            - zoo1
+            - zoo2
+            - zoo3
             - kafka1
             - kafka2
             - kafka3
+        ports:
+            - 9021:9021
+        environment:
+            CONTROL_CENTER_REST_LISTENERS: "http://0.0.0.0:9021"
+            CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka1:19092,kafka2:19093,kafka3:19094"
+            CONTROL_CENTER_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+            CONTROL_CENTER_REPLICATION_FACTOR: 2
+            CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+            CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 2
+            CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+            CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 2
+            CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
+            PORT: 9021
 
     zoo1:
         image: zookeeper:3.4.9
@@ -63,7 +70,7 @@ services:
 
 
     kafka1:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka1
         ports:
@@ -74,7 +81,13 @@ services:
             KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
             KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
             KAFKA_BROKER_ID: 1
+            KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka1:19092"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
             - ./cluster-data/kafka1/data:/var/lib/kafka/data
         depends_on:
@@ -83,7 +96,7 @@ services:
             - zoo3
 
     kafka2:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka2
         ports:
@@ -94,7 +107,13 @@ services:
             KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
             KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
             KAFKA_BROKER_ID: 2
+            KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka2:19093"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
             - ./cluster-data/kafka2/data:/var/lib/kafka/data
         depends_on:
@@ -103,7 +122,7 @@ services:
             - zoo3
 
     kafka3:
-        image: confluentinc/cp-kafka:5.5.1
+        image: confluentinc/cp-enterprise-kafka:5.5.1
         restart: always
         hostname: kafka3
         ports:
@@ -114,7 +133,13 @@ services:
             KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
             KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
             KAFKA_BROKER_ID: 3
+            KAFKA_BROKER_RACK: "r1"
             KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+            KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+            CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 3
+            CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "kafka3:19094"
+            CONFLUENT_METRICS_REPORTER_MAX_REQUEST_SIZE: 10485760
+            CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
         volumes:
             - ./cluster-data/kafka3/data:/var/lib/kafka/data
         depends_on:


### PR DESCRIPTION
- `docker-compose.yml` contains open source version of Kafka with Confluent Control Center only useful for watching topics
- `docker-compose.enterprise.yml` contains enterprise version of Kafka with Confluent Control Center metrics